### PR TITLE
Add action section to the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,10 @@
       "matches": ["*://calendar.google.com/*"],
       "js": ["change_background.js"]
     }
-  ]
+  ],
 
+  "action": {
+    "default_title": "Highlights current week",
+    "default_icon": "icons/g_background_48.png"
+  }
 }


### PR DESCRIPTION
Otherwise the icon shows disabled, which is misleading.

https://developer.chrome.com/docs/extensions/reference/api/action