### PR TITLE
Make xpath more reliable

### DIFF
--- a/change_background.js
+++ b/change_background.js
@@ -29,7 +29,7 @@ function removeUiCustomizations() {
 function updateUi() {
     let current_week_number = (new Date()).getWeek();
     let week_element = document.evaluate(
-        '//*/header//*[text()="Week ' + current_week_number + '"]',
+        '//*/header//div[normalize-space(.)="Week ' + current_week_number + '"]',
         document,
         null,
         XPathResult.FIRST_ORDERED_NODE_TYPE,


### PR DESCRIPTION
Looks like now the div has two text nodes, so trim spaces before matching

<img width="651" height="128" alt="Sysdig_-_Calendar_-_Week_of_July_7__2025" src="https://github.com/user-attachments/assets/d57de775-943d-469b-87f3-0abc2d94c1c1" />
